### PR TITLE
Fix case of include du-ino_sh1106.h for case sensitive filesystems

### DIFF
--- a/src/du-ino_sh1106.cpp
+++ b/src/du-ino_sh1106.cpp
@@ -25,7 +25,7 @@
 #include <avr/pgmspace.h>
 #include <util/atomic.h>
 #include "du-ino_font5x7.h"
-#include "du-ino_SH1106.h"
+#include "du-ino_sh1106.h"
 
 static uint8_t buffer[SH1106_LCDHEIGHT * SH1106_LCDWIDTH / 8];
 


### PR DESCRIPTION
I'm assuming this is usually compiled on windows or osx with the default case insensitive file system but on linux it won't be able to find the header.

```
Multiple libraries were found for "du-ino_function.h"
/home/eiginn/Arduino/libraries/du_ino/src/du-ino_sh1106.cpp:28:10: fatal error: du-ino_SH1106.h: No such file or directory
 Used: /home/eiginn/Arduino/libraries/du_ino
 #include "du-ino_SH1106.h"
```